### PR TITLE
Update w2dynamics Git hash

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,10 +26,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {os: ubuntu-22.04, cc: gcc-12, cxx: g++-12}
-          - {os: ubuntu-22.04, cc: clang-15, cxx: clang++-15}
-          - {os: macos-12, cc: gcc-12, cxx: g++-12}
-          - {os: macos-12, cc: clang, cxx: clang++}
+          - {os: ubuntu-24.04, cc: gcc, cxx: g++}
+          - {os: ubuntu-24.04, cc: clang, cxx: clang++}
+          - {os: macos-14, cc: gcc-14, cxx: g++-14}
+          - {os: macos-14, cc: clang, cxx: clang++}
 
     runs-on: ${{ matrix.os }}
 
@@ -44,23 +44,22 @@ jobs:
           ccache-${{ matrix.os }}-${{ matrix.cc }}-
 
     - name: Install ubuntu dependencies
-      if: matrix.os == 'ubuntu-22.04'
+      if: ${{ contains(matrix.os, 'ubuntu') }}
       run: >
         sudo apt-get update &&
         sudo apt-get install lsb-release wget software-properties-common &&
-        wget -O /tmp/llvm.sh https://apt.llvm.org/llvm.sh && sudo chmod +x /tmp/llvm.sh && sudo /tmp/llvm.sh 15 &&
         sudo apt-get install
         ccache
-        clang-15
-        g++-12
+        clang
+        g++
         gfortran
         hdf5-tools
         libblas-dev
         libboost-dev
-        libclang-15-dev
-        libc++-15-dev
-        libc++abi-15-dev
-        libomp-15-dev
+        libclang-dev
+        libc++-dev
+        libc++abi-dev
+        libomp-dev
         libfftw3-dev
         libnfft3-dev
         libgfortran5
@@ -71,7 +70,7 @@ jobs:
         openmpi-bin
         openmpi-common
         openmpi-doc
-        python3-clang-15
+        python3-clang
         python3-configobj
         python3-dev
         python3-h5py
@@ -84,34 +83,37 @@ jobs:
         python3-sphinx
         python3-nbsphinx
 
-    - name: Install homebrew dependencies
-      if: matrix.os == 'macos-12'
+    - name: Set up virtualenv
       run: |
-        brew install ccache gcc@12 llvm boost fftw hdf5 open-mpi openblas
-        brew install wentzell/triqs/nfft
         mkdir $HOME/.venv
-        python3 -m venv $HOME/.venv/my_python
+        python3 -m venv --system-site-packages $HOME/.venv/my_python
         source $HOME/.venv/my_python/bin/activate
-        pip install mako numpy scipy mpi4py
-        pip install -r requirements.txt
-        echo "FC=gfortran-13" >> $GITHUB_ENV
-        echo "BLAS_ROOT=$(brew --prefix)/opt/openblas" >> $GITHUB_ENV
-        echo "LAPACK_ROOT=$(brew --prefix)/opt/openblas" >> $GITHUB_ENV
         echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> $GITHUB_ENV
         echo "PATH=$PATH" >> $GITHUB_ENV
 
-    - name: add clang cxxflags
+    - name: Install homebrew dependencies
+      if: ${{ contains(matrix.os, 'macos') }}
+      run: |
+        brew update
+        brew install ccache gcc llvm boost fftw hdf5 open-mpi openblas
+        brew install wentzell/triqs/nfft
+        pip install mako numpy scipy mpi4py
+        pip install -r requirements.txt
+        echo "PATH=$(brew --prefix llvm)/bin:$(brew --prefix gcc)/bin:$PATH" >> $GITHUB_ENV
+        echo "PYTHONPATH=$(brew --prefix llvm)/lib/python3.13/site-packages" >> $GITHUB_ENV
+
+    - name: Add clang CXXFLAGS
       if: ${{ contains(matrix.cxx, 'clang') }}
       run: |
-        echo "PATH=/usr/local/opt/llvm/bin:$PATH" >> $GITHUB_ENV
         echo "CXXFLAGS=-stdlib=libc++" >> $GITHUB_ENV
 
     - name: Build & Install TRIQS
       env:
         CC: ${{ matrix.cc }}
         CXX: ${{ matrix.cxx }}
+        TRIQS_BRANCH: ${{ github.event_name == 'pull_request' && github.base_ref || github.ref_name }}
       run: |
-        git clone https://github.com/TRIQS/triqs --branch unstable
+        git clone https://github.com/TRIQS/triqs --branch $TRIQS_BRANCH
         mkdir triqs/build && cd triqs/build
         cmake .. -DBuild_Tests=OFF -DCMAKE_INSTALL_PREFIX=$HOME/install
         make -j1 install VERBOSE=1
@@ -121,7 +123,6 @@ jobs:
       env:
         CC: ${{ matrix.cc }}
         CXX: ${{ matrix.cxx }}
-        LIBRARY_PATH: /usr/local/opt/llvm/lib
       run: |
         source $HOME/install/share/triqs/triqsvars.sh
         mkdir build && cd build && cmake ..
@@ -129,7 +130,6 @@ jobs:
 
     - name: Test w2dynamics_interface
       env:
-        DYLD_FALLBACK_LIBRARY_PATH: /usr/local/opt/llvm/lib
         OPENBLAS_NUM_THREADS: "1"
       run: |
         source $HOME/install/share/triqs/triqsvars.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ message(STATUS "-------- BUILD-TYPE: ${CMAKE_BUILD_TYPE} --------")
 
 # w2dynamics specific variables
 get_property(FFTW_LIBRARIES TARGET triqs::fftw PROPERTY INTERFACE_LINK_LIBRARIES)
-set(W2DYN_GIT_HASH v1.1.5)
+set(W2DYN_GIT_HASH 1cd69a7cd0431f96b9d473835e84593f3066d8f7)
 message(STATUS "w2dynamics git hash: ${W2DYN_GIT_HASH}")
 
 include(FetchContent)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 # Sphinx has internal caching, always run it
 add_custom_target(${PROJECT_NAME}_docs_sphinx ALL)
 add_custom_command(
-  TARGET ${PROJECT_NAME}_docs_sphinx
+  TARGET ${PROJECT_NAME}_docs_sphinx POST_BUILD
   COMMAND PYTHONPATH=${PROJECT_BINARY_DIR}/python:$ENV{PYTHONPATH} ${SPHINXBUILD_EXECUTABLE} -j auto -c . -b html ${CMAKE_CURRENT_SOURCE_DIR} html
 )
 


### PR DESCRIPTION
We need this [upstream fix from w2dynamics](https://github.com/w2dynamics/w2dynamics/commit/a7f4612bffad19feece6f98eae7050b629cea1ae) to be able to build against glibc 2.40.

To get the CI to work again I also merged [app4triqs/unstable](https://github.com/TRIQS/app4triqs/tree/d61b2c66979f2861d312dcf793b4982c02fcf621).